### PR TITLE
Fix satellite emoji to use dish (📡)

### DIFF
--- a/src/satellite/app.py
+++ b/src/satellite/app.py
@@ -44,7 +44,7 @@ class SatelliteApp(App):
 
     # Terminal tab title (reactive to ensure driver is ready)
     terminal_title: var[str] = var("Satellite")
-    terminal_title_icon: var[str] = var("🛰️")
+    terminal_title_icon: var[str] = var("📡")
 
     BINDINGS = [
         Binding("f1", "toggle_help", "Help"),

--- a/src/satellite/screens/main.py
+++ b/src/satellite/screens/main.py
@@ -162,7 +162,7 @@ class MainScreen(Screen):
     def _get_info(self) -> str:
         """Generate app info text."""
         return f"""\
-🛰️ [bold]{APP_INFO["name"]}[/bold] [dim]v{APP_INFO["version"]}[/dim]  [@click=screen.open_logs][underline]Logs[/underline][/]
+📡 [bold]{APP_INFO["name"]}[/bold] [dim]v{APP_INFO["version"]}[/dim]  [@click=screen.open_logs][underline]Logs[/underline][/]
 [#50FA7B]{APP_INFO["tagline"]}[/#50FA7B]
 
 


### PR DESCRIPTION
## Summary
- Replace orbiting satellite emoji (🛰️) with satellite dish emoji (📡) in terminal tab title and main screen banner

## Test plan
- [ ] Run app and verify 📡 appears in Ghostty tab title
- [ ] Verify 📡 appears in the main screen info banner

🤖 Generated with [Claude Code](https://claude.ai/code)