### PR TITLE
Fix uv subprocess cwd resolution when launched outside project root

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ uv run satellite
 
 ### Run Evaluations
 
-Run any combination of the five telecom benchmarks against your chosen model:
+Run any combination of the telecom benchmarks against your chosen model.
+Satellite discovers available benchmarks from `evals._registry` automatically.
 
 | Benchmark | Required Samples |
 |-----------|-----------------|
@@ -62,6 +63,8 @@ Run any combination of the five telecom benchmarks against your chosen model:
 | TeleMath  | 100             |
 | TeleTables| 100             |
 | 3GPP      | 100             |
+| ORANBench | 150             |
+| srsRANBench | 150           |
 
 Track running jobs with live progress bars, cancel jobs in progress, and inspect detailed scores and token usage per job. The Settings tab lets you configure sample limits, epochs, max connections, and token limits.
 
@@ -86,7 +89,7 @@ To submit results, you need a GitHub token with the following permissions scoped
 - `contents:read` and `contents:write`
 - `pull_requests:write`
 
-All five benchmarks must be completed with the required sample counts before submission is allowed.
+All currently registered benchmarks must be completed with the required sample counts before submission is allowed.
 
 ## Development
 

--- a/docs/how_to_add_new_evals.md
+++ b/docs/how_to_add_new_evals.md
@@ -1,140 +1,55 @@
-# How to Add New Evaluations
+# How New Evals Flow Into Satellite
 
-This guide explains how new evaluations flow from the `gsma-labs/evals` repository into the satellite TUI.
+Satellite now auto-discovers evaluations from `evals._registry.__all__`.
 
-## Architecture Overview
+## What Is Automatic
 
-```
-otelcos/evals                          satellite
-┌─────────────────────┐               ┌─────────────────────────────┐
-│ src/evals/          │               │ services/eval_registry.py   │
-│   _registry.py      │──imports──────│   EVAL_METADATA             │
-│   __all__ = [       │               │   get_available_evals()     │
-│     "teleqna",      │               └──────────────┬──────────────┘
-│     "new_eval",     │                              │
-│   ]                 │                              ▼
-└─────────────────────┘               ┌─────────────────────────────┐
-                                      │ UI Components               │
-                                      │   - Run Evals Modal         │
-                                      │   - Leaderboard Modal       │
-                                      └─────────────────────────────┘
-```
+When a new task is added in `gsma-labs/evals/src/evals/_registry.py`, Satellite will automatically:
 
-## When a New Eval is Added to otelcos/evals
+1. Show it in **Run Evals**.
+2. Load it in the eval worker.
+3. Add it to leaderboard/submit layouts.
+4. Include it in eligibility checks.
 
-1. **Automatic**: The eval ID appears in `evals._registry.__all__`
-2. **Manual**: You must add metadata to satellite's `EVAL_METADATA`
+No per-eval hardcoding is needed in Satellite for normal additions.
 
-## Step-by-Step: Adding a New Eval
+## Required Step After Evals Changes
 
-### Step 1: Update Dependencies
-
-After otelcos/evals adds a new evaluation, update your dependencies:
+Satellite still needs an updated `evals` dependency:
 
 ```bash
 cd satellite
-uv sync --upgrade-package evals
+uv lock --upgrade-package evals
+uv sync --dev
 ```
 
-### Step 2: Add Metadata to eval_registry.py
-
-Open `src/satellite/services/eval_registry.py` and add an entry to `EVAL_METADATA`:
-
-```python
-EVAL_METADATA: dict[str, dict] = {
-    # ... existing evals ...
-
-    "new_eval_id": {
-        "name": "New Eval Display Name",    # Full name shown in UI
-        "short_name": "Short",              # Column header in leaderboard (max ~6 chars)
-        "description": "What this evaluation tests",
-        "hf_column": "column_in_huggingface",  # Column name in GSMA/leaderboard dataset
-    },
-}
-```
-
-### Step 3: Verify
-
-Run satellite and check:
+## Quick Verification
 
 ```bash
-uv run python -m satellite
+uv run python -c "import evals._registry as r; print(r.__all__)"
+uv run pytest tests/services/test_submit_eligibility.py tests/services/test_parquet_builder.py -q
 ```
 
-1. Press `2` (Evals) → The new eval should appear in the list
-2. Press `3` (Preview Leaderboard) → The new column should appear (with `--` if no data yet)
+Then run the UI:
 
-## Field Reference
-
-| Field | Description | Example |
-|-------|-------------|---------|
-| `name` | Full display name | `"TeleQnA"` |
-| `short_name` | Leaderboard column header | `"QnA"` |
-| `description` | Shown below the name in eval list | `"Question answering benchmark"` |
-| `hf_column` | Column name in HuggingFace dataset | `"teleqna"` |
-
-## Finding the HuggingFace Column Name
-
-The leaderboard data comes from the `GSMA/leaderboard` dataset on HuggingFace. To find the correct column name:
-
-1. Visit https://huggingface.co/datasets/GSMA/leaderboard
-2. Look at the dataset columns
-3. Match the new eval's column name
-
-Common patterns:
-- `teleqna` → `"teleqna"`
-- `three_gpp` → `"3gpp_tsg"`
-
-## What Happens Without Metadata
-
-If an eval exists in the registry but lacks metadata in satellite:
-
-1. A warning is logged: `No metadata for eval 'new_eval_id' - add to EVAL_METADATA`
-2. The eval is **not shown** in the UI
-3. The leaderboard won't display that column
-
-## Example: Adding "TeleConfig" Eval
-
-Suppose otelcos/evals adds a new `teleconfig` evaluation:
-
-```python
-# In src/satellite/services/eval_registry.py
-
-EVAL_METADATA: dict[str, dict] = {
-    "teleqna": { ... },
-    "telelogs": { ... },
-    "telemath": { ... },
-    "teletables": { ... },
-    "three_gpp": { ... },
-
-    # New eval
-    "teleconfig": {
-        "name": "TeleConfig",
-        "short_name": "Config",
-        "description": "Network configuration understanding benchmark",
-        "hf_column": "teleconfig",
-    },
-}
-```
-
-## Troubleshooting
-
-### Eval not appearing in UI
-
-1. Check the registry is updated:
-   ```bash
-   uv run python -c "from evals._registry import __all__; print(__all__)"
-   ```
-2. Check metadata exists in `EVAL_METADATA`
-3. Check for typos in the eval ID
-
-### Leaderboard shows "--" for all entries
-
-The HuggingFace dataset may not have data for this eval yet. This is expected for new evals.
-
-### Import errors after updating
-
-Run a clean sync:
 ```bash
-uv sync --reinstall-package evals
+uv run satellite
 ```
+
+## Metadata Behavior
+
+Satellite derives benchmark metadata from each task module with safe fallbacks:
+
+1. `hf_column`: from `DEFAULT_DATASET_NAME` when available, else eval id.
+2. Name/short name/description: known overrides for core benchmarks, generated fallback for new ones.
+3. Required sample count: known overrides for official leaderboard benchmarks; best-effort inference for unknown tasks.
+
+## Recommended Automation Workflow
+
+To keep Satellite synced with frequent eval additions:
+
+1. Add a scheduled GitHub Action that runs `uv lock --upgrade-package evals`.
+2. Run CI tests on that branch.
+3. Auto-open a PR with lockfile updates when changes are detected.
+
+This keeps dependency updates reproducible while eliminating manual registry/layout edits.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "textual>=7.5.0",
     "huggingface-hub>=0.20.0",
     "pyarrow>=14.0.0",
-    "evals @ git+https://github.com/otelcos/evals.git@faa7c3489",
+    "evals @ git+https://github.com/gsma-labs/evals.git@main",
     "inspect-ai>=0.3.170,<0.4",
     "openai>=2.16.0",
     "python-dotenv>=1.0.0",

--- a/src/satellite/app.py
+++ b/src/satellite/app.py
@@ -16,11 +16,13 @@ from textual.app import App
 from textual.binding import Binding
 from textual.reactive import var
 
+from satellite import PACKAGE_ROOT
 from satellite.screens.main import MainScreen
 from satellite.services.evals import EvalRunner, JobManager
 
 INSPECT_VIEW_PORT = 7575
 INSPECT_VIEW_CMD = ("uv", "run", "inspect", "view")
+UV_PROJECT_ROOT = PACKAGE_ROOT.parent.parent
 VIEW_SHUTDOWN_TIMEOUT = 3
 VIEW_HEALTH_CHECK_DELAY = 1.0
 
@@ -97,6 +99,7 @@ class SatelliteApp(App):
         try:
             self._view_process = subprocess.Popen(
                 cmd,
+                cwd=UV_PROJECT_ROOT,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 stdin=subprocess.DEVNULL,
@@ -250,13 +253,10 @@ def main() -> None:
 
     # Evals registry - triggers full inspect-ai initialization
     try:
-        from evals._registry import (  # noqa: F401
-            telelogs,
-            telemath,
-            teleqna,
-            teletables,
-            three_gpp,
-        )
+        import evals._registry as _evals_registry  # noqa: F401
+
+        # Touch __all__ so registry imports are executed before Textual takes over.
+        _ = getattr(_evals_registry, "__all__", ())
     except ImportError:
         pass  # evals not installed, will use fallback metadata
 

--- a/src/satellite/modals/scripts/submit_modal.py
+++ b/src/satellite/modals/scripts/submit_modal.py
@@ -114,11 +114,12 @@ class SubmitModal(ModalScreen[SubmitResult | None]):
         scroll = self.query_one("#model-list-scroll", VerticalScroll)
 
         if not self._eligible_models:
+            benchmark_names = ", ".join(b.name for b in BENCHMARKS_BY_ID.values())
             description.update(
                 "[warning]No eligible models found.[/]\n\n"
                 "A model is eligible when it has completed [bold]all[/bold] "
                 f"{len(BENCHMARKS_BY_ID)} benchmarks\n"
-                "(TeleQnA, TeleLogs, TeleMath, TeleTables, 3GPP)\n"
+                f"({benchmark_names})\n"
                 "with valid scores."
             )
             return

--- a/src/satellite/services/evals/inspect_progress_hook.py
+++ b/src/satellite/services/evals/inspect_progress_hook.py
@@ -134,7 +134,10 @@ class SatelliteProgressHooks(Hooks):
             progress.updated_at = _utc_now_iso()
             progress.last_sample_id = data.sample_id
 
-            if progress.planned_units > 0 and progress.completed_units > progress.planned_units:
+            if (
+                progress.planned_units > 0
+                and progress.completed_units > progress.planned_units
+            ):
                 progress.completed_units = progress.planned_units
 
         await self._write()
@@ -163,7 +166,9 @@ class SatelliteProgressHooks(Hooks):
                 if isinstance(total_samples, int) and total_samples > 0:
                     progress.planned_units = total_samples
                 if isinstance(completed_samples, int) and completed_samples >= 0:
-                    progress.completed_units = max(progress.completed_units, completed_samples)
+                    progress.completed_units = max(
+                        progress.completed_units, completed_samples
+                    )
 
         await self._write()
 
@@ -198,4 +203,3 @@ class SatelliteProgressHooks(Hooks):
                     pass  # Progress reporting is best-effort; don't crash the eval.
 
             await anyio.to_thread.run_sync(_write_sync)
-

--- a/src/satellite/services/evals/job_manager.py
+++ b/src/satellite/services/evals/job_manager.py
@@ -83,7 +83,9 @@ def _safe_int(value: object, default: int = 0) -> int:
         return default
 
 
-def _estimate_job_total_units(evals: dict[str, list[str]], settings: EvalSettings) -> int:
+def _estimate_job_total_units(
+    evals: dict[str, list[str]], settings: EvalSettings
+) -> int:
     """Estimate total planned work units for a job from its manifest and settings."""
     total = 0
     limit = settings.limit
@@ -193,7 +195,9 @@ def _aggregate_progress(
                     done = 0
                     if isinstance(progress_entry, dict):
                         done = _safe_int(progress_entry.get("completed_units"), 0)
-                        sidecar_planned = _safe_int(progress_entry.get("planned_units"), 0)
+                        sidecar_planned = _safe_int(
+                            progress_entry.get("planned_units"), 0
+                        )
                         if sidecar_planned > 0:
                             planned = sidecar_planned
                     if done == 0:
@@ -493,7 +497,9 @@ class JobManager:
 
             settings = EvalSettings(
                 limit=inferred_limit if inferred_limit is not None else settings.limit,
-                epochs=inferred_epochs if inferred_epochs is not None else settings.epochs,
+                epochs=inferred_epochs
+                if inferred_epochs is not None
+                else settings.epochs,
                 max_connections=settings.max_connections,
                 token_limit=settings.token_limit,
                 message_limit=settings.message_limit,
@@ -547,7 +553,9 @@ class JobManager:
         settings = EvalSettings(
             limit=raw_settings.get("limit"),
             epochs=raw_settings.get("epochs", defaults.epochs),
-            max_connections=raw_settings.get("max_connections", defaults.max_connections),
+            max_connections=raw_settings.get(
+                "max_connections", defaults.max_connections
+            ),
             token_limit=raw_settings.get("token_limit"),
             message_limit=raw_settings.get("message_limit"),
         )

--- a/src/satellite/services/evals/registry.py
+++ b/src/satellite/services/evals/registry.py
@@ -1,6 +1,19 @@
-"""Benchmark definitions - the canonical list of evaluations."""
+"""Benchmark registry.
 
+Satellite discovers benchmark tasks from ``evals._registry.__all__`` so newly
+added evaluations in ``gsma-labs/evals`` appear in the UI automatically.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
 from dataclasses import dataclass
+from importlib import import_module
+from types import ModuleType
+from typing import Callable
+
+_log = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -17,57 +30,219 @@ class BenchmarkConfig:
     total_samples: int
 
 
+_NAME_OVERRIDES: dict[str, str] = {
+    "teleqna": "TeleQnA",
+    "telelogs": "TeleLogs",
+    "telemath": "TeleMath",
+    "teletables": "TeleTables",
+    "three_gpp": "3GPP",
+    "oranbench": "ORANBench",
+    "srsranbench": "srsRANBench",
+}
+
+_SHORT_NAME_OVERRIDES: dict[str, str] = {
+    "teleqna": "QnA",
+    "telelogs": "Logs",
+    "telemath": "Math",
+    "teletables": "Tables",
+    "three_gpp": "3GPP",
+    "oranbench": "ORAN",
+    "srsranbench": "srsRAN",
+}
+
+_DESCRIPTION_OVERRIDES: dict[str, str] = {
+    "teleqna": "Question answering benchmark for telecom domain",
+    "telelogs": "Log analysis and troubleshooting benchmark",
+    "telemath": "Mathematical reasoning for telecom calculations",
+    "teletables": "Table understanding and extraction benchmark",
+    "three_gpp": "3GPP specification understanding benchmark",
+    "oranbench": "O-RAN specification understanding benchmark",
+    "srsranbench": "srsRAN codebase understanding benchmark",
+}
+
+# Required sample counts for leaderboard eligibility (small benchmark split).
+_SAMPLE_COUNT_OVERRIDES: dict[str, int] = {
+    "teleqna": 1000,
+    "telelogs": 100,
+    "telemath": 100,
+    "teletables": 100,
+    "three_gpp": 100,
+    "oranbench": 150,
+    "srsranbench": 150,
+}
+
+_FALLBACK_BENCHMARK_IDS: tuple[str, ...] = (
+    "teleqna",
+    "telelogs",
+    "telemath",
+    "teletables",
+    "three_gpp",
+)
+
+
+def _module_path_for(eval_id: str) -> str:
+    return f"evals.{eval_id}.{eval_id}"
+
+
+def _import_optional(module_path: str) -> ModuleType | None:
+    try:
+        return import_module(module_path)
+    except Exception:
+        return None
+
+
+def _display_name(eval_id: str) -> str:
+    override = _NAME_OVERRIDES.get(eval_id)
+    if override:
+        return override
+
+    words = []
+    for token in eval_id.replace("-", "_").split("_"):
+        if not token:
+            continue
+        if token.isdigit():
+            words.append(token)
+            continue
+        lower = token.lower()
+        if lower in {"gpp", "ran", "llm", "qa"}:
+            words.append(token.upper())
+            continue
+        words.append(token.capitalize())
+    return " ".join(words) if words else eval_id
+
+
+def _short_name(eval_id: str, name: str) -> str:
+    override = _SHORT_NAME_OVERRIDES.get(eval_id)
+    if override:
+        return override
+
+    parts = [p for p in name.replace("-", " ").split() if p]
+    if len(parts) > 1:
+        acronym = "".join(p[0].upper() for p in parts if p[0].isalnum())
+        if 2 <= len(acronym) <= 6:
+            return acronym
+    if parts:
+        return parts[0][:7]
+    return eval_id[:7]
+
+
+def _description(eval_id: str, name: str) -> str:
+    override = _DESCRIPTION_OVERRIDES.get(eval_id)
+    if override:
+        return override
+    return f"{name} evaluation benchmark"
+
+
+def _hf_column(eval_id: str, module: ModuleType | None) -> str:
+    if module is not None:
+        dataset_name = getattr(module, "DEFAULT_DATASET_NAME", None)
+        if isinstance(dataset_name, str) and dataset_name.strip():
+            return dataset_name.strip()
+    return eval_id
+
+
+def _sample_count_from_task(task: object) -> int:
+    dataset = getattr(task, "dataset", None)
+    if dataset is None:
+        return 0
+
+    samples = getattr(dataset, "samples", None)
+    if isinstance(samples, int):
+        return max(samples, 0)
+    if isinstance(samples, (list, tuple, set, dict)):
+        return len(samples)
+    if samples is not None:
+        try:
+            return len(samples)
+        except TypeError:
+            pass
+    try:
+        return len(dataset)
+    except TypeError:
+        return 0
+
+
+def _callable_without_args(task_fn: Callable[..., object]) -> bool:
+    try:
+        sig = inspect.signature(task_fn)
+    except (TypeError, ValueError):
+        return False
+    for param in sig.parameters.values():
+        if param.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            continue
+        if param.default is inspect.Parameter.empty:
+            return False
+    return True
+
+
+def _total_samples(eval_id: str, task_fn: Callable[..., object] | None) -> int:
+    override = _SAMPLE_COUNT_OVERRIDES.get(eval_id)
+    if override is not None:
+        return override
+
+    if task_fn is None or not _callable_without_args(task_fn):
+        return 0
+
+    try:
+        task = task_fn()
+        return _sample_count_from_task(task)
+    except Exception as exc:
+        _log.debug("Could not infer sample count for %s: %s", eval_id, exc)
+        return 0
+
+
+def _build_config(
+    eval_id: str,
+    task_fn: Callable[..., object] | None,
+) -> BenchmarkConfig:
+    module_path = getattr(task_fn, "__module__", _module_path_for(eval_id))
+    function_name = getattr(task_fn, "__name__", eval_id)
+    module = _import_optional(module_path)
+    name = _display_name(eval_id)
+    return BenchmarkConfig(
+        id=eval_id,
+        name=name,
+        short_name=_short_name(eval_id, name),
+        description=_description(eval_id, name),
+        hf_column=_hf_column(eval_id, module),
+        module_path=module_path,
+        function_name=function_name,
+        total_samples=_total_samples(eval_id, task_fn),
+    )
+
+
+def _discover_benchmarks() -> tuple[BenchmarkConfig, ...]:
+    try:
+        registry_module = import_module("evals._registry")
+    except Exception:
+        return ()
+
+    eval_ids = getattr(registry_module, "__all__", ())
+    if not isinstance(eval_ids, list | tuple):
+        return ()
+
+    discovered: list[BenchmarkConfig] = []
+    seen: set[str] = set()
+    for eval_id in eval_ids:
+        if not isinstance(eval_id, str) or not eval_id or eval_id in seen:
+            continue
+        seen.add(eval_id)
+        task_fn = getattr(registry_module, eval_id, None)
+        if task_fn is not None and not callable(task_fn):
+            task_fn = None
+        discovered.append(_build_config(eval_id, task_fn))
+    return tuple(discovered)
+
+
+def _fallback_benchmarks() -> tuple[BenchmarkConfig, ...]:
+    return tuple(_build_config(eval_id, None) for eval_id in _FALLBACK_BENCHMARK_IDS)
+
+
 BENCHMARKS: tuple[BenchmarkConfig, ...] = (
-    BenchmarkConfig(
-        id="teleqna",
-        name="TeleQnA",
-        short_name="QnA",
-        description="Question answering benchmark for telecom domain",
-        hf_column="teleqna",
-        module_path="evals.teleqna.teleqna",
-        function_name="teleqna",
-        total_samples=1000,
-    ),
-    BenchmarkConfig(
-        id="telelogs",
-        name="TeleLogs",
-        short_name="Logs",
-        description="Log analysis and troubleshooting benchmark",
-        hf_column="telelogs",
-        module_path="evals.telelogs.telelogs",
-        function_name="telelogs",
-        total_samples=100,
-    ),
-    BenchmarkConfig(
-        id="telemath",
-        name="TeleMath",
-        short_name="Math",
-        description="Mathematical reasoning for telecom calculations",
-        hf_column="telemath",
-        module_path="evals.telemath.telemath",
-        function_name="telemath",
-        total_samples=100,
-    ),
-    BenchmarkConfig(
-        id="teletables",
-        name="TeleTables",
-        short_name="Tables",
-        description="Table understanding and extraction benchmark",
-        hf_column="teletables",
-        module_path="evals.teletables.teletables",
-        function_name="teletables",
-        total_samples=100,
-    ),
-    BenchmarkConfig(
-        id="three_gpp",
-        name="3GPP",
-        short_name="3GPP",
-        description="3GPP specification understanding benchmark",
-        hf_column="3gpp_tsg",
-        module_path="evals.three_gpp.three_gpp",
-        function_name="three_gpp",
-        total_samples=100,
-    ),
+    _discover_benchmarks() or _fallback_benchmarks()
 )
 
 BENCHMARKS_BY_ID: dict[str, BenchmarkConfig] = {b.id: b for b in BENCHMARKS}

--- a/src/satellite/services/evals/runner.py
+++ b/src/satellite/services/evals/runner.py
@@ -12,6 +12,7 @@ import threading
 from pathlib import Path
 from typing import NamedTuple
 
+from satellite import PACKAGE_ROOT
 from satellite.services.config import EvalSettings
 from satellite.services.evals.job_manager import Job
 from satellite.services.evals.worker import mark_started_logs_cancelled
@@ -19,6 +20,7 @@ from satellite.services.evals.worker import mark_started_logs_cancelled
 CANCELLED_EXIT_CODE = 2
 CANCELLED_MARKER = "cancelled"
 WORKER_CMD = ["uv", "run", "python", "-m", "satellite.services.evals.worker"]
+UV_PROJECT_ROOT = PACKAGE_ROOT.parent.parent
 
 
 class EvalResult(NamedTuple):
@@ -167,6 +169,7 @@ class EvalRunner:
 
         process = subprocess.Popen(
             WORKER_CMD,
+            cwd=UV_PROJECT_ROOT,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/src/satellite/services/submit/parquet_builder.py
+++ b/src/satellite/services/submit/parquet_builder.py
@@ -15,15 +15,15 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 from inspect_ai.log import EvalLog, read_eval_log
 
-from satellite.services.evals import BENCHMARKS_BY_ID
+from satellite.services.evals import BENCHMARKS, BENCHMARKS_BY_ID
 
 if TYPE_CHECKING:
     from satellite.services.submit import SubmitPreview
 
 MODEL_CARDS_DIR = "model_cards"
 
-# Parquet columns in leaderboard order
-SCORE_COLUMNS = ("teleqna", "telelogs", "telemath", "3gpp_tsg", "teletables")
+# Parquet score columns in registry order (deduplicated by hf_column).
+SCORE_COLUMNS = tuple(dict.fromkeys(b.hf_column for b in BENCHMARKS))
 
 _PATH_TRAVERSAL_PATTERNS = ("..", "/", "\\")
 

--- a/tests/integration/test_eval_runner.py
+++ b/tests/integration/test_eval_runner.py
@@ -5,7 +5,6 @@ Run with: uv run pytest tests/integration/test_eval_runner.py -v
 """
 
 import os
-from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -14,8 +13,8 @@ from dotenv import load_dotenv
 from inspect_ai.log import list_eval_logs
 
 from satellite.services.config import EvalSettings
-from satellite.services.evals import EvalRunner
-from satellite.services.evals.job_manager import Job, JobManager
+from satellite.services.evals import BENCHMARKS_BY_ID, EvalRunner
+from satellite.services.evals.job_manager import Job
 from satellite.services.evals.worker import load_task
 
 load_dotenv(Path(__file__).parent.parent.parent / ".env")
@@ -37,13 +36,7 @@ class TestTaskLoading:
 
     @pytest.mark.parametrize(
         "benchmark_id",
-        [
-            pytest.param("teleqna", id="teleqna"),
-            pytest.param("telelogs", id="telelogs"),
-            pytest.param("telemath", id="telemath"),
-            pytest.param("teletables", id="teletables"),
-            pytest.param("three_gpp", id="three_gpp"),
-        ],
+        [pytest.param(benchmark_id, id=benchmark_id) for benchmark_id in BENCHMARKS_BY_ID],
     )
     def test_load_valid_benchmark(self, benchmark_id: str) -> None:
         """All declared benchmarks should load successfully."""

--- a/uv.lock
+++ b/uv.lock
@@ -502,8 +502,8 @@ wheels = [
 
 [[package]]
 name = "evals"
-version = "0.0.1.dev111+unknown.gfaa7c3489"
-source = { git = "https://github.com/otelcos/evals.git?rev=faa7c3489#faa7c3489d3e2b8c2ee00f5d8fa6cfba51287499" }
+version = "1.0.1.dev7+g2d329bfb0"
+source = { git = "https://github.com/gsma-labs/evals.git?rev=main#2d329bfb0950dcba5acc97b429a77d0c01d7df59" }
 dependencies = [
     { name = "datasets" },
     { name = "inspect-ai" },
@@ -2740,7 +2740,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "evals", git = "https://github.com/otelcos/evals.git?rev=faa7c3489" },
+    { name = "evals", git = "https://github.com/gsma-labs/evals.git?rev=main" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "huggingface-hub", specifier = ">=0.20.0" },
     { name = "inspect-ai", specifier = ">=0.3.170,<0.4" },


### PR DESCRIPTION
## Summary
- set explicit project-root cwd for inspect view subprocess in SatelliteApp
- set explicit project-root cwd for eval worker subprocess in EvalRunner
- add regression tests that fail without cwd and pass with the fix

## Testing
- uv run pytest tests/services/test_fd_leaks.py::TestAppViewProcessPipeFdLeak::test_launch_view_uses_project_root_cwd tests/services/test_eval_subprocess.py::TestRunEvalSetSubprocess::test_uses_project_root_cwd_for_uv_resolution -q
- uv run pytest tests/services/test_fd_leaks.py tests/services/test_eval_subprocess.py tests/test_app_subprocess_cleanup.py -q
- uv run ruff check src/satellite/app.py src/satellite/services/evals/runner.py tests/services/test_fd_leaks.py tests/services/test_eval_subprocess.py

Closes #18