### PR TITLE
Add Claude Code review workflow for PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,6 +18,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
@@ -48,6 +49,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:


### PR DESCRIPTION
## Summary
- Adds automatic Claude Code review workflow triggered on PRs to `main`
- Includes `id-token: write` permission for OIDC authentication
- Supports interactive `@claude` mentions in PR comments

## Note
This must be merged to `main` before the claude-code-action OIDC token exchange works on other PRs (bootstrap requirement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)