### PR TITLE
Fix make setup uv path resolution under sudo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,9 @@ cd satellite
 make setup
 ```
 
-> **Linux note:** `make setup` will use `sudo` to install system libraries (libcairo2-dev).
-> Do **not** run `sudo make setup` — this will break the Python environment.
+> **Linux note:** `make setup` may use `sudo` to install system libraries (libcairo2-dev).
+> Running `sudo make setup` is supported: Python dependencies are installed as the invoking user (`$SUDO_USER`), not in `/root`.
+> Running `make setup` directly as root (without `SUDO_USER`) is not supported.
 > If you prefer to install system deps separately:
 > ```bash
 > sudo apt-get install -y libcairo2-dev pkg-config

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ make setup
 
 `make setup` installs Python 3.13, all dependencies, and registers the `satellite` command.
 
-> **Linux note:** `make setup` will use `sudo` to install system libraries (libcairo2-dev).
-> Do **not** run `sudo make setup` — this will break the Python environment.
+> **Linux note:** `make setup` may use `sudo` to install system libraries (libcairo2-dev).
+> Running `sudo make setup` is supported: Python dependencies are installed as the invoking user (`$SUDO_USER`), not in `/root`.
+> Running `make setup` directly as root (without `SUDO_USER`) is not supported.
 > If you prefer to install system deps separately:
 > ```bash
 > sudo apt-get install -y libcairo2-dev pkg-config


### PR DESCRIPTION
Summary:
- run Python setup as the original invoking user when make setup is executed via sudo
- resolve uv via $HOME/.local/bin/uv after install to avoid PATH propagation issues
- keep system package installation in deps and add focused setup tests

Validation:
- make -n setup
- uv run pytest tests/test_makefile_setup.py -v
- uv run pytest tests/services/test_job_progress_sidecar.py -v
- uv run ruff check src/satellite/services/evals/inspect_progress_hook.py src/satellite/services/evals/job_manager.py tests/test_makefile_setup.py

Closes #12