### PR TITLE
fix: prevent TUI crash on incomplete eval logs

### DIFF
--- a/src/satellite/modals/scripts/job_detail_modal.py
+++ b/src/satellite/modals/scripts/job_detail_modal.py
@@ -29,6 +29,8 @@ STATUS_COLORS: dict[str, str] = {
     "cancelled": "#FFB86C",
 }
 
+RECOVERABLE_REFRESH_ERRORS = (RuntimeError, OSError, ValueError)
+
 
 def _format_tokens(total: int) -> str:
     """Format token count with K/M suffix."""
@@ -156,7 +158,7 @@ class JobDetailModal(ModalScreen[None]):
         try:
             self._results = self._job_manager.get_job_results(self._job.id)
             self._details = self._job_manager.get_job_details(self._job.id)
-        except Exception as exc:
+        except RECOVERABLE_REFRESH_ERRORS as exc:
             _log.debug("Skipping refresh for job %s: %s", self._job.id, exc)
             return
 

--- a/src/satellite/services/evals/job_manager.py
+++ b/src/satellite/services/evals/job_manager.py
@@ -34,6 +34,8 @@ STATUS_PRIORITY: dict[JobStatus, int] = {
     "success": 3,
 }
 
+RECOVERABLE_LOG_READ_ERRORS = (ValueError, OSError, RuntimeError)
+
 
 def _map_log_status(log: EvalLog) -> JobStatus:
     """Map an EvalLog status to a JobStatus, treating 'started' as 'running'."""
@@ -118,7 +120,7 @@ def _count_completed_samples(log_ref: object) -> int:
                 time.sleep(0.05)
                 continue
             return 0
-        except Exception:
+        except (OSError, RuntimeError):
             return 0
     return 0
 
@@ -138,7 +140,7 @@ def _log_ref_dir(log_ref: object) -> Path | None:
     # Fallback: treat name as a local path.
     try:
         return Path(name).expanduser().resolve().parent
-    except Exception:
+    except (OSError, RuntimeError, ValueError):
         return None
 
 
@@ -304,7 +306,7 @@ def _read_eval_log_header_safe(log_path: object) -> EvalLog | None:
 
     try:
         return read_eval_log(log_path, header_only=True)
-    except Exception as exc:
+    except RECOVERABLE_LOG_READ_ERRORS as exc:
         _log.debug("Skipping unreadable eval log %s: %s", log_path, exc)
         return None
 

--- a/tests/modals/test_job_detail_results.py
+++ b/tests/modals/test_job_detail_results.py
@@ -213,6 +213,17 @@ class TestJobDetailModalResultsDisplay:
             assert "0.72" in score_text_after
             assert manager.get_job_results.call_count == 2
 
+    def test_fetch_update_propagates_unexpected_exception(
+        self, sample_job: Job
+    ) -> None:
+        """Unexpected exceptions should propagate instead of being silently swallowed."""
+        manager = MagicMock(spec=JobManager)
+        manager.get_job_results.side_effect = TypeError("unexpected")
+        modal = JobDetailModal(job=sample_job, job_manager=manager)
+
+        with pytest.raises(TypeError):
+            modal._fetch_and_update()
+
 
 # ============================================================================
 # Test Class 2: Job Selection Fetches Results (Bug Fix Verification)


### PR DESCRIPTION
## Summary\n- skip unreadable/partial Inspect logs while they are being written\n- harden aggregate/status paths to use safe header reads\n- guard JobDetailModal polling refresh so backend read errors do not crash the TUI\n- add regression tests for service and modal crash paths\n\n## Linked Issue\nCloses #15